### PR TITLE
Don't convert line endings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Set git line endings
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - uses: actions/checkout@v3
     - name: Install
       run: rustup install ${{ matrix.channel }}
@@ -34,6 +38,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
+    - name: Set git line endings
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - uses: actions/checkout@v3
     - name: Install nightly
       run: rustup install nightly


### PR DESCRIPTION
Converting to Windows newline messes up rustfmt.