### PR TITLE
Add `posix{,_lexically}_absolute_from` APIs to PosixPathExt

### DIFF
--- a/crates/omnipath/src/posix.rs
+++ b/crates/omnipath/src/posix.rs
@@ -74,12 +74,27 @@ pub trait PosixPathExt: Sealed {
 	///     let path = Path::new("path/to/..//./file");
 	///
 	///     assert_eq!(
-	///         &path.posix_absolute_from(working_dir),
+	///         &path.posix_absolute_from(working_dir).unwrap(),
 	///         Path::new("/tmp/path/to/../file"),
 	///     )
 	/// }
 	/// ```
-	fn posix_absolute_from(&self, path: &Path) -> PathBuf;
+	///
+	/// ```
+	/// #[cfg(unix)]
+	/// {
+	///     use omnipath::posix::PosixPathExt;
+	///     use std::path::Path;
+	///     use std::env::current_dir;
+	///		let root = Path::new("/tmp/foo//.././bar");
+	///     let path = Path::new(r"path/to/..//./file");
+	///     assert_eq!(
+	///         &path.posix_absolute_from(root).unwrap(),
+	///         Path::new("/tmp/foo/../bar/path/to/../file"),
+	///     );
+	/// }
+	/// ```
+	fn posix_absolute_from(&self, path: &Path) -> io::Result<PathBuf>;
 
 	/// [Unix only] Make a POSIX path lexically absolute relative to a provided
 	/// current working directory.
@@ -105,108 +120,60 @@ pub trait PosixPathExt: Sealed {
 	///		let root = Path::new("/tmp");
 	///     let path = Path::new(r"path/to/..//./file");
 	///     assert_eq!(
-	///         &path.posix_lexically_absolute_from(root),
+	///         &path.posix_lexically_absolute_from(root).unwrap(),
 	///         Path::new("/tmp/path/file")
-	///     )
+	///     );
 	/// }
 	/// ```
-	fn posix_lexically_absolute_from(&self, cwd: &Path) -> PathBuf;
+	///
+	/// ```
+	/// #[cfg(unix)]
+	/// {
+	///     use omnipath::posix::PosixPathExt;
+	///     use std::path::Path;
+	///     use std::env::current_dir;
+	///		let root = Path::new("/tmp/foo//.././bar");
+	///     let path = Path::new(r"path/to/..//./file");
+	///     assert_eq!(
+	///         &path.posix_lexically_absolute_from(root).unwrap(),
+	///         Path::new("/tmp/bar/path/file")
+	///     );
+	/// }
+	/// ```
+	fn posix_lexically_absolute_from(&self, cwd: &Path) -> io::Result<PathBuf>;
 }
 
 impl PosixPathExt for Path {
 	fn posix_absolute(&self) -> io::Result<PathBuf> {
-		Ok(self.posix_absolute_from(&env::current_dir()?))
+		posix_absolute_from(self, env::current_dir)
 	}
 
 	fn posix_lexically_absolute(&self) -> io::Result<PathBuf> {
-		Ok(self.posix_lexically_absolute_from(&env::current_dir()?))
+		posix_lexically_absolute_from(self, env::current_dir)
 	}
 
-	fn posix_absolute_from(&self, cwd: &Path) -> PathBuf {
-		// This is mostly a wrapper around collecting `Path::components`, with
-		// exceptions made where this conflicts with the POSIX specification.
-		// See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
-		// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
-
-		// Get the components, skipping the redundant leading "." component if it exists.
-		let mut components = self.strip_prefix(".").unwrap_or(self).components();
-		let path_os = self.as_os_str().as_bytes();
-
-		let mut normalized = if self.is_absolute() {
-			// "If a pathname begins with two successive <slash> characters, the
-			// first component following the leading <slash> characters may be
-			// interpreted in an implementation-defined manner, although more than
-			// two leading <slash> characters shall be treated as a single <slash>
-			// character."
-			if path_os.starts_with(b"//") && !path_os.starts_with(b"///") {
-				components.next();
-				PathBuf::from("//")
-			} else {
-				PathBuf::new()
-			}
-		} else {
-			cwd.into()
-		};
-		normalized.extend(components);
-
-		// "Interfaces using pathname resolution may specify additional constraints
-		// when a pathname that does not name an existing directory contains at
-		// least one non- <slash> character and contains one or more trailing
-		// <slash> characters".
-		// A trailing <slash> is also meaningful if "a symbolic link is
-		// encountered during pathname resolution".
-		if path_os.ends_with(b"/") {
-			normalized.push("");
+	fn posix_absolute_from(&self, cwd: &Path) -> io::Result<PathBuf> {
+		if !cwd.is_absolute() {
+			return Err(cwd_error());
 		}
-
-		normalized
+		posix_absolute_from(self, || posix_absolute_from(cwd, || unreachable!()))
 	}
 
-	fn posix_lexically_absolute_from(&self, cwd: &Path) -> PathBuf {
-		// This is mostly a wrapper around collecting `Path::components`, with
-		// exceptions made where this conflicts with the POSIX specification.
-		// See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
-		// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
-
-		// Get the components, skipping the redundant leading "." component if it exists.
-		let mut components = self.strip_prefix(".").unwrap_or(self).components();
-		let path_os = self.as_os_str().as_bytes();
-
-		let mut normalized = if self.is_absolute() {
-			// "If a pathname begins with two successive <slash> characters, the
-			// first component following the leading <slash> characters may be
-			// interpreted in an implementation-defined manner, although more than
-			// two leading <slash> characters shall be treated as a single <slash>
-			// character."
-			if path_os.starts_with(b"//") && !path_os.starts_with(b"///") {
-				components.next();
-				PathBuf::from("//")
-			} else {
-				PathBuf::new()
-			}
-		} else {
-			cwd.into()
-		};
-		components.for_each(|component| {
-			if component == Component::ParentDir {
-				normalized.pop();
-			} else {
-				normalized.push(component);
-			}
-		});
-
-		// "Interfaces using pathname resolution may specify additional constraints
-		// when a pathname that does not name an existing directory contains at
-		// least one non- <slash> character and contains one or more trailing
-		// <slash> characters".
-		// A trailing <slash> is also meaningful if "a symbolic link is
-		// encountered during pathname resolution".
-		if path_os.ends_with(b"/") {
-			normalized.push("");
+	fn posix_lexically_absolute_from(&self, cwd: &Path) -> io::Result<PathBuf> {
+		if !cwd.is_absolute() {
+			return Err(cwd_error());
 		}
-
-		normalized
+		posix_lexically_absolute_from(self, || {
+			posix_lexically_absolute_from(cwd, || unreachable!())
+		})
 	}
+}
+
+fn cwd_error() -> io::Error {
+	io::Error::new(
+		io::ErrorKind::InvalidInput,
+		"expected an absolute path as the current working directory",
+	)
 }
 
 mod private {
@@ -214,3 +181,95 @@ mod private {
 	impl Sealed for std::path::Path {}
 }
 use private::Sealed;
+
+fn posix_lexically_absolute_from<F>(path: &Path, get_cwd: F) -> io::Result<PathBuf>
+where
+	F: FnOnce() -> io::Result<PathBuf>,
+{
+	// This is mostly a wrapper around collecting `Path::components`, with
+	// exceptions made where this conflicts with the POSIX specification.
+	// See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
+	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+
+	// Get the components, skipping the redundant leading "." component if it exists.
+	let mut components = path.strip_prefix(".").unwrap_or(path).components();
+	let path_os = path.as_os_str().as_bytes();
+
+	let mut normalized = if path.is_absolute() {
+		// "If a pathname begins with two successive <slash> characters, the
+		// first component following the leading <slash> characters may be
+		// interpreted in an implementation-defined manner, although more than
+		// two leading <slash> characters shall be treated as a single <slash>
+		// character."
+		if path_os.starts_with(b"//") && !path_os.starts_with(b"///") {
+			components.next();
+			PathBuf::from("//")
+		} else {
+			PathBuf::new()
+		}
+	} else {
+		get_cwd()?
+	};
+	components.for_each(|component| {
+		if component == Component::ParentDir {
+			normalized.pop();
+		} else {
+			normalized.push(component);
+		}
+	});
+
+	// "Interfaces using pathname resolution may specify additional constraints
+	// when a pathname that does not name an existing directory contains at
+	// least one non- <slash> character and contains one or more trailing
+	// <slash> characters".
+	// A trailing <slash> is also meaningful if "a symbolic link is
+	// encountered during pathname resolution".
+	if path_os.ends_with(b"/") {
+		normalized.push("");
+	}
+
+	Ok(normalized)
+}
+
+fn posix_absolute_from<F>(path: &Path, get_cwd: F) -> io::Result<PathBuf>
+where
+	F: FnOnce() -> io::Result<PathBuf>,
+{
+	// This is mostly a wrapper around collecting `Path::components`, with
+	// exceptions made where this conflicts with the POSIX specification.
+	// See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
+	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
+
+	// Get the components, skipping the redundant leading "." component if it exists.
+	let mut components = path.strip_prefix(".").unwrap_or(path).components();
+	let path_os = path.as_os_str().as_bytes();
+
+	let mut normalized = if path.is_absolute() {
+		// "If a pathname begins with two successive <slash> characters, the
+		// first component following the leading <slash> characters may be
+		// interpreted in an implementation-defined manner, although more than
+		// two leading <slash> characters shall be treated as a single <slash>
+		// character."
+		if path_os.starts_with(b"//") && !path_os.starts_with(b"///") {
+			components.next();
+			PathBuf::from("//")
+		} else {
+			PathBuf::new()
+		}
+	} else {
+		get_cwd()?
+	};
+	normalized.extend(components);
+
+	// "Interfaces using pathname resolution may specify additional constraints
+	// when a pathname that does not name an existing directory contains at
+	// least one non- <slash> character and contains one or more trailing
+	// <slash> characters".
+	// A trailing <slash> is also meaningful if "a symbolic link is
+	// encountered during pathname resolution".
+	if path_os.ends_with(b"/") {
+		normalized.push("");
+	}
+
+	Ok(normalized)
+}


### PR DESCRIPTION
Still unclear how best to handle cases where the user-provided `cwd` is either not absolute or is absolute but messy.

I think ideally the first is an error (which means these functions probably still need to return `io::Result`, but the second is resolved in a manner consistent with the rest of the function...